### PR TITLE
Use one sentence per line formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # Middleware Olympics
 
-Middlewares are complex. Middleware comparisons are complex. There are
-many dimensions of tradeoffs that go into the design and implementation
-of middlewares, so any evaluation needs to consider many different
-use cases. The goal of this repo is to have a bunch of little programs
-to experiment with various middlewares to learn more about their pros and
-cons.
+Middlewares are complex.
+Middleware comparisons are complex.
+There are many dimensions of tradeoffs that go into the design and implementation of middlewares, so any evaluation needs to consider many different use cases.
+The goal of this repo is to have a bunch of little programs to experiment with various middlewares to learn more about their pros and cons.
 
 ### The Contestants
 
@@ -33,14 +31,15 @@ cons.
 
 https://github.com/eclipse-zenoh/zenoh/tree/rust-master
 
-It seems that Zenoh needs the very latest rust, rather than a version of
-rust from a distribution package manager that may be somewhat older. So
-if you have Rust already installed in Ubuntu, you'll need to do this first:
+It seems that Zenoh needs the very latest rust, rather than a version of rust from a distribution package manager that may be somewhat older.
+So if you have Rust already installed in Ubuntu, you'll need to do this first:
+
 ```
 sudo apt remove rustc
 ```
 
 Now, install the latest rust using its official installer:
+
 ```
 mkdir -p ~/olympics/rust
 cd ~/olympics/rust
@@ -51,12 +50,15 @@ rustup install nightly
 ```
 
 Now if you close the current shell and open a new one, this should work:
+
 ```
 which rustc
 ```
+
 should be something like `/home/USERNAME/.cargo/bin/rustc`
 
 Now we can install the development branch of Zenoh:
+
 ```
 mkdir ~/olympics
 cd ~/olympics


### PR DESCRIPTION
One sentence per line, no word wrapping (except virtual wrapping in your editor, which is easy in Vim and I'm sure you wouldn't think of using anything else) makes diffs much easier because each sentence's changes can be viewed independently, and a change in a sentence causing a change in wrapping doesn't turn the whole paragraph into one big change.